### PR TITLE
Fix Bug and New Feature: allow user to choose from BibLaTeX and BibTeX

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,12 +21,12 @@
   "contributes": {
     "commands": [
       {
-        "command": "zotex.exportBibLatex",
-        "title": "Zotex: Export BibLaTeX"
+        "command": "zotex.exportBib",
+        "title": "Zotex: Export Bib"
       },
       {
-        "command": "zotex.flushBibLatex",
-        "title": "Zotex: Export BibLaTeX (flush with overwritting and sorting)"
+        "command": "zotex.flushBib",
+        "title": "Zotex: Export Bib (flush with overwritting and sorting)"
       },
       {
         "command": "zotex.addCitation",
@@ -63,11 +63,11 @@
     ],
     "commandPalette": [
       {
-        "command": "zotex.exportBibLatex",
+        "command": "zotex.exportBib",
         "when": "editorLangId == 'latex' || editorLangId == 'markdown'"
       },
       {
-        "command": "zotex.flushBibLatex",
+        "command": "zotex.flushBib",
         "when": "editorLangId == 'latex' || editorLangId == 'markdown'"
       },
       {
@@ -149,6 +149,12 @@
             "default": false,
             "scope": "window",
             "description": "Minimize all Zotero windows after picking a citation"
+          },
+          "zotex.bibliographyPackage": {
+            "type": "string",
+            "default": "biblatex",
+            "scope": "window",
+            "description": "Default bibliography package, biblatex or bibtex"
           }
         }
       }

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,5 +1,5 @@
 import got from "got"
-import { serverUrl, bibliograpyStyle, minimizeAfterPicking } from "./config"
+import { serverUrl, bibliograpyStyle, minimizeAfterPicking, bibliographyPackage } from "./config"
 
 /**
  * 调用zotero citation picker获取citekeys
@@ -41,7 +41,7 @@ export async function getBibliography(keys: string[]) {
   let payload = {
     jsonrpc: "2.0",
     method: "item.export",
-    params: [keys, "biblatex"],
+    params: [keys, bibliographyPackage()],
   }
 
   // requests bibliography

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,10 @@ export function minimizeAfterPicking() {
   return vscode.workspace.getConfiguration('zotex').get('minimizeAfterPicking', false);
 }
 
+export function bibliographyPackage() {
+  return vscode.workspace.getConfiguration('zotex').get('bibliographyPackage', false);
+}
+
 export async function setWorkspaceBibPath(context: vscode.ExtensionContext) {
   let latestBibName = context.workspaceState.get<string>('latestBibName');
 

--- a/src/export-bib.ts
+++ b/src/export-bib.ts
@@ -9,7 +9,7 @@ import * as vscode from "vscode"
 /**
  * 根据latex和markdown环境的不同，导出所有的bibliography到文件中
  */
-export async function exportBibLatex(context: vscode.ExtensionContext) {
+export async function exportBib(context: vscode.ExtensionContext) {
   try {
     const editor = window.activeTextEditor
     if (editor === undefined) {
@@ -74,7 +74,7 @@ export async function exportBibLatex(context: vscode.ExtensionContext) {
 /**
  * 强制刷新bib文件，覆盖、排序
  */
-export async function flushBibLatex(context: vscode.ExtensionContext) {
+export async function flushBib(context: vscode.ExtensionContext) {
   try {
     const editor = window.activeTextEditor
     if (editor === undefined) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,7 @@
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
 
-import { exportBibLatex, flushBibLatex } from './export-bib';
+import { exportBib, flushBib } from './export-bib';
 import { addCitation, addZoteroSelectedCitation } from './add-cite';
 import { addCiteBib, addZoteroSelectedCiteBib } from './add-cite-bib';
 import { addMdCiteBib } from './add-md-bib';
@@ -21,11 +21,11 @@ export function activate(context: vscode.ExtensionContext) {
 	// The command has been defined in the package.json file
 	// Now provide the implementation of the command with registerCommand
 	// The commandId parameter must match the command field in package.json
-	context.subscriptions.push(vscode.commands.registerCommand('zotex.exportBibLatex', async () => {
-		await exportBibLatex(context);
+	context.subscriptions.push(vscode.commands.registerCommand('zotex.exportBib', async () => {
+		await exportBib(context);
 	}));
-	context.subscriptions.push(vscode.commands.registerCommand('zotex.flushBibLatex', async () => {
-		await flushBibLatex(context);
+	context.subscriptions.push(vscode.commands.registerCommand('zotex.flushBib', async () => {
+		await flushBib(context);
 	}));
 	context.subscriptions.push(vscode.commands.registerCommand('zotex.addCiteBib', async () => {
 		await addCiteBib(context);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,7 +29,7 @@ function getCiteKeyList(keyMatchList: any[]) {
   keyMatchList.forEach(
     (/** @type {string[]} */ v: string[], /** @type {any} */ i: any) => {
       // 处理latex的情况
-      let a = v[0].replace(/^cite/, "")
+      let a = v[0].replace(/^cite(t|p)?(\*)?(author|year)?/, "")
       let p = /(\w|\d)+/g
       let keyMatches = getMatchList(p, a)
       keyMatches.forEach((vi) => {


### PR DESCRIPTION
Two commits are included in this pull request:
1. Fix Bug: the feature supporting commands like "citet{}" etc. in natbib didn't function well. In this commit, I fixed the bug.
2. New Feature: to use natbib, users will need BibTeX instead of BibLaTeX. Hence, I modified code as follows:
    1. Add a config option to choose from BibTeX or BibLaTeX with default value being BibLaTeX;
    2. Due to functional changes, the original command names like "export BibLaTex" or "flush BibLaTeX" might be confusing. I changed the command names to "export Bib" etc.

p.s. I really like this plugin, and I appreciate the original author's efforts.